### PR TITLE
Fixes github URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/tilap/koa-request-logger.git"
+    "url": "git+ssh://git@github.com/tilap/koa-request-log.git"
   },
   "keywords": [
     "koa"
@@ -23,10 +23,10 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/tilap/koa-request-logger/issues"
+    "url": "https://github.com/tilap/koa-request-log/issues"
   },
   "license": "MIT",
-  "homepage": "https://github.com/tilap/koa-request-logger#readme",
+  "homepage": "https://github.com/tilap/koa-request-log#readme",
   "dependencies": {
     "assert": "1.3.0",
     "shortid": "2.2.6"


### PR DESCRIPTION
The npm page leads to 404 since the package.json points to https://github.com/tilap/koa-request-logger instead of https://github.com/tilap/koa-request-log.
