### PR TITLE
Interpolate the method name

### DIFF
--- a/src/koa-request-logger.js
+++ b/src/koa-request-logger.js
@@ -6,7 +6,7 @@ const defaultFormat = (ctx, id, isIn = true, timeDiff = null) => (isIn ?
   `[${id} OUT] ${ctx.request.method} ${ctx.request.url} [${ctx.status}] ${timeDiff}ms`);
 
 module.exports = ({ logger = console, method = 'log', format = defaultFormat } = {}) => {
-  assert(logger.hasOwnProperty(method), new Error('Logger does not have the method "${method}"'));
+  assert(logger.hasOwnProperty(method), new Error(`Logger does not have the method "${method}"`));
   return async (ctx, next) => {
     const start = Date.now();
     const id = shortid.generate();


### PR DESCRIPTION
Previously the error looked like `Error: Logger does not have the method "${method}"`

now it should look like `Error: Logger does not have the method "info"`